### PR TITLE
Add support for scheduler_zombie_task_threshold

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -189,6 +189,11 @@ airflow_job_heartbeat_sec: 5
 # how often the scheduler should run (in seconds).
 airflow_scheduler_heartbeat_sec: 5
 
+# Local task jobs periodically heartbeat to the DB. If the job has
+# not heartbeat in this many seconds, the scheduler will mark the
+# associated task instance as failed and will re-schedule the task.
+airflow_scheduler_zombie_task_threshold: 300
+
 # The scheduler can run multiple threads in parallel to schedule dags.
 # This defines how many threads will run. However airflow will never
 # use more threads than the amount of cpu cores available.

--- a/templates/airflow.cfg.j2
+++ b/templates/airflow.cfg.j2
@@ -179,6 +179,11 @@ job_heartbeat_sec = {{ airflow_job_heartbeat_sec }}
 # how often the scheduler should run (in seconds).
 scheduler_heartbeat_sec = {{ airflow_scheduler_heartbeat_sec }}
 
+# Local task jobs periodically heartbeat to the DB. If the job has
+# not heartbeat in this many seconds, the scheduler will mark the
+# associated task instance as failed and will re-schedule the task.
+scheduler_zombie_task_threshold = {{ airflow_scheduler_zombie_task_threshold }}
+
 {% if airflow_statsd_on == True %}
 # Statsd (https://github.com/etsy/statsd) integration settings
 statsd_on = {{ airflow_statsd_on }}


### PR DESCRIPTION
👋 

This is a new `airflow.cfg` setting that was not available for configuration using your Ansible role.

```
# Local task jobs periodically heartbeat to the DB. If the job has
# not heartbeat in this many seconds, the scheduler will mark the
# associated task instance as failed and will re-schedule the task.
scheduler_zombie_task_threshold = 300
```

This allows it to be configured via `airflow_scheduler_zombie_task_threshold`